### PR TITLE
[Fix] default swagger OpenAPI path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <description>chess controller service</description>
     <properties>
         <java.version>17</java.version>
+        <springdoc.swagger-ui.url>/v3/api-docs</springdoc.swagger-ui.url>
+        <springdoc.swagger-ui.disable-swagger-default-url>true</springdoc.swagger-ui.disable-swagger-default-url>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
The default OpenAPI path was not correct

https://backend.chess.valentinriess.com/swagger-ui/index.html