### PR TITLE
[Fix] Use newer dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.0</version>
+        <version>2.6.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.chess</groupId>
@@ -15,6 +15,7 @@
     <description>chess controller service</description>
     <properties>
         <java.version>17</java.version>
+        <log4j2.version>2.17.1</log4j2.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
As a java project, this project might be affected by log4j-core vulnerabilities CVE-2021-44832, CVE-2021-45046 and CVE-2021-45105. These are fixed in newer versions of this library which should be used consequently to mitigate this issue.