### PR TITLE
[Feature] Add helper method for simulation

### DIFF
--- a/src/main/java/com/chess/backend/gamemodel/Chessboard.java
+++ b/src/main/java/com/chess/backend/gamemodel/Chessboard.java
@@ -33,9 +33,14 @@ import java.util.ArrayList;
  */
 @Data
 @IgnoreExtraProperties
-public class Chessboard implements IBoard {
+public class Chessboard implements IBoard, Cloneable {
     private int numberOfPlayers;
     private ArrayList<ArrayList<Square>>  squares;//squares of chessboard
     private boolean breakCastling = false; //if last move break castling
     private Moves moves_history;
+
+    public Object clone() throws CloneNotSupportedException
+    {
+        return super.clone();
+    }
 }

--- a/src/main/java/com/chess/backend/services/ChessGameService.java
+++ b/src/main/java/com/chess/backend/services/ChessGameService.java
@@ -2,17 +2,12 @@ package com.chess.backend.services;
 
 import com.chess.backend.domain.models.IGame;
 import com.chess.backend.domain.repository.IGameRepository;
-import com.chess.backend.domain.services.IGameService;
-import com.chess.backend.domain.services.INewGameService;
 import com.chess.backend.gamemodel.*;
-import com.chess.backend.domain.models.IPiece;
 import com.chess.backend.gamemodel.constants.Event;
 import com.chess.backend.gamemodel.constants.PieceType;
 import com.chess.backend.gamemodel.pieces.Piece;
-import com.chess.backend.repository.GameRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;

--- a/src/main/java/com/chess/backend/services/ChessboardService.java
+++ b/src/main/java/com/chess/backend/services/ChessboardService.java
@@ -7,7 +7,6 @@ import com.chess.backend.gamemodel.pieces.*;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -594,5 +593,24 @@ public class ChessboardService {
         }
 
         return capturedPlayers;
+    }
+
+    /**
+     * Get all allowed moves of a given piece by a given owner.
+     * This can be used to simulate possible shoots of a canon, when another player is on turn.
+     * @param chessboard Chessboard which acts as base for the simulation
+     * @param piece Piece for which the moves should be gathered. This also defines what pieces get owned by the player in the simulation.
+     * @param player The player wo should own all pieces of the same type as the given piece
+     * @return ArrayList of all "reachable" squares.
+     */
+    public static ArrayList<Square> getAllowedMovesForPlayer(Chessboard chessboard, Piece piece, Player player){
+        try {
+            Chessboard dummyChessboard = (Chessboard) chessboard.clone();
+            ChessboardService.setCommonPiecePlayer(dummyChessboard, piece.getType(), player);
+            return piece.getAllowedMoves(dummyChessboard);
+        } catch (CloneNotSupportedException e) {
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
     }
 }


### PR DESCRIPTION
Adds a new helper method that clones a chessboard and calculates possbíble moves of a piece after reowning pieces of the same piecetype. This can be used for the cannon piece.