### PR TITLE
fix: updated the base position

### DIFF
--- a/src/main/java/com/chess/backend/services/PlayerService.java
+++ b/src/main/java/com/chess/backend/services/PlayerService.java
@@ -39,6 +39,6 @@ public class PlayerService {
      * @return Player object in Y
      */
     public static int getBaseY(Player player) {
-        return player.getColor().getPosition() * 9;
+        return player.getColor().getPosition() * 10;
     }
 }


### PR DESCRIPTION
The base player position was not updated, so the setup of the player pieces is wrong.

Example:
- For a three player game the space between white and green is larger than between white and black.